### PR TITLE
fix: github-readme-stats not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
     <img src="http://github-profile-summary-cards.vercel.app/api/cards/stats?username=bik1111&theme=transparent" />
   </a>
   <a href="https://github.com/bik1111">
-    <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=bik1111&langs_count=10&exclude_repo=&hide=jupyter%20notebook,vim%20script,cmake,makefile,batchfile,emacs%20lisp,css,html&layout=default&card_width=699&hide_border=true&theme=transparent" />
+    <img src="https://github-readme-stats.vercel.app/api/top-langs/?username=bik1111&langs_count=10&exclude_repo=&hide=jupyter%20notebook,vim%20script,cmake,makefile,batchfile,emacs%20lisp,css,html&card_width=699&hide_border=true&theme=transparent" />
   </a>
 </p>
 </details>


### PR DESCRIPTION
`layout` 파라미터는 `default`를 지원하지 않습니다.
의미론상 생략을 통해 기본값을 유도했습니다.

velog는 알 수 없는 오류로 인해 고칠 수 없었습니다.
관련 저장소에도 관련 Issue가 없어서 올려보시는게 좋을 것 같습니다.